### PR TITLE
✨ (ui) ビルド時にバージョン情報を生成する機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# build version info (generated at build time)
+/lib/version.json

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
+import { VersionInfo } from '@/components/version-info'
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -23,11 +24,14 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="ja">
+    <html lang="ja" className="h-full">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-background text-foreground`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground h-full flex flex-col`}
       >
-        {children}
+        <div className="flex-1">{children}</div>
+        <footer className="w-full mt-auto">
+          <VersionInfo />
+        </footer>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ export default async function HomePage({
   const weekLabel = getWeekLabel(weekId)
 
   return (
-    <main className="min-h-screen">
+    <main>
       <Header />
 
       {/* Week Info Section */}

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -22,7 +22,7 @@ export default async function SubmitPage({
 
   if (!session) {
     return (
-      <main className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-blue-50 flex items-center justify-center p-4">
+      <main className="bg-gradient-to-br from-purple-50 via-white to-blue-50 flex items-center justify-center p-4 min-h-[80vh]">
         <div className="bg-white rounded-3xl shadow-2xl p-12 max-w-md w-full text-center">
           <div className="mb-8">
             <div className="w-20 h-20 bg-gradient-primary rounded-2xl mx-auto mb-4 flex items-center justify-center">

--- a/components/version-info.tsx
+++ b/components/version-info.tsx
@@ -1,0 +1,24 @@
+import versionData from '@/lib/version.json'
+
+export function VersionInfo() {
+  const { commitSha, buildDate } = versionData
+
+  // Format the build date in a more readable way
+  const formattedDate = new Date(buildDate).toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Tokyo',
+  })
+
+  return (
+    <div className="text-xs text-muted-foreground text-center py-4 pb-24 md:pb-4">
+      <div>
+        Version: <span className="font-mono">{commitSha}</span>
+      </div>
+      <div>Built: {formattedDate}</div>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/set-version.js && next build",
     "start": "next start",
     "lint": "eslint .",
     "test": "firebase emulators:exec --only firestore \"vitest run\"",

--- a/scripts/set-version.js
+++ b/scripts/set-version.js
@@ -1,0 +1,43 @@
+/**
+ * Version情報を取得するためのスクリプト
+ * Commit Hashと Build Dateを取得して、version.jsonに書き出す
+ * @typedef {Object} VersionInfo
+ * @property {string} commitSha - Git commit SHA (short)
+ * @property {string} buildDate - Build date in ISO format
+ */
+
+const { execSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+try {
+  // Get the current git commit SHA (short version)
+  const commitSha = execSync('git rev-parse --short HEAD').toString().trim()
+
+  // Get the current date and time
+  const buildDate = new Date().toISOString()
+
+  // Create version info object
+  /** @type {VersionInfo} */
+  const versionInfo = {
+    commitSha,
+    buildDate,
+  }
+
+  // Write to a JSON file that can be imported
+  const outputPath = path.join(__dirname, '..', 'lib', 'version.json')
+  fs.writeFileSync(outputPath, JSON.stringify(versionInfo, null, 2))
+
+  console.log('Version info generated:')
+  console.log(`  Commit SHA: ${commitSha}`)
+  console.log(`  Build Date: ${buildDate}`)
+} catch (error) {
+  console.error('Error generating version info:', error.message)
+  // Write a fallback version
+  const fallbackVersion = {
+    commitSha: 'unknown',
+    buildDate: new Date().toISOString(),
+  }
+  const outputPath = path.join(__dirname, '..', 'lib', 'version.json')
+  fs.writeFileSync(outputPath, JSON.stringify(fallbackVersion, null, 2))
+}


### PR DESCRIPTION
- 新しいスクリプト `set-version.js` を追加し、コミットハッシュとビルド日時を取得して `lib/version.json` に書き出す。
- `layout.tsx` に `VersionInfo` コンポーネントを追加し、フッターにバージョン情報を表示。
- `package.json` のビルドスクリプトを更新し、ビルド前にバージョン情報を生成するように変更。
- `.gitignore` に `lib/version.json` を追加し、生成されたファイルを無視するように設定。
