### PR TITLE
🔧 Fix: Server ActionでsignOutを実行するように修正

### DIFF
--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -24,8 +24,44 @@ export default async function SubmitPage({
 
   // Force logout if session has invalid user ID (old UUID format instead of Snowflake)
   if (session && !isValidSnowflake(session.user?.id)) {
-    await signOut()
-    redirect('/submit')
+    return (
+      <main className="bg-gradient-to-br from-purple-50 via-white to-blue-50 flex items-center justify-center p-4 min-h-[80vh]">
+        <div className="bg-white rounded-3xl shadow-2xl p-12 max-w-md w-full text-center">
+          <div className="mb-8">
+            <div className="w-20 h-20 bg-orange-500 rounded-2xl mx-auto mb-4 flex items-center justify-center">
+              <span className="text-4xl">⚠️</span>
+            </div>
+            <h1 className="text-3xl font-bold mb-3">セッションの更新が必要です</h1>
+            <p className="text-muted-foreground">
+              古いセッション形式を検出しました。
+              <br />
+              再度ログインしてください。
+            </p>
+          </div>
+          <form
+            action={async () => {
+              'use server'
+              await signOut()
+            }}
+          >
+            <Button
+              size="lg"
+              className="w-full bg-orange-500 hover:bg-orange-600 text-white py-6 text-lg font-semibold"
+            >
+              ログアウトして再ログイン
+            </Button>
+          </form>
+          <div className="mt-8 pt-6 border-t">
+            <Link
+              href="/"
+              className="text-sm text-muted-foreground hover:text-purple-600 transition-colors"
+            >
+              ← 公開ページへ戻る
+            </Link>
+          </div>
+        </div>
+      </main>
+    )
   }
 
   if (!session) {


### PR DESCRIPTION
## 概要
Server Componentから直接`signOut()`を呼び出すとCookieエラーが発生する問題を修正しました。

## 問題
Cloud Run環境で以下のエラーが発生していました：
```
Error: Cookies can only be modified in a Server Action or Route Handler.
```

これは、Server Componentから直接`signOut()`を呼び出していたためです。`signOut()`はCookieを変更するため、Server ActionまたはRoute Handlerの中でのみ使用可能です。

## 修正内容
古いセッション（UUID形式）を検出した際の処理を変更：

**修正前:**
```typescript
if (session && !isValidSnowflake(session.user?.id)) {
  await signOut()  // ❌ Server Componentから直接呼び出し
  redirect('/submit')
}
```

**修正後:**
```typescript
if (session && !isValidSnowflake(session.user?.id)) {
  return (
    <main>
      {/* 警告画面を表示 */}
      <form action={async () => {
        'use server'  // ✅ Server Action
        await signOut()
      }}>
        <Button>ログアウトして再ログイン</Button>
      </form>
    </main>
  )
}
```

## 変更点
- 古いセッション検出時に警告画面を表示
- ⚠️ オレンジ色のアイコンと「セッションの更新が必要です」メッセージ
- ユーザーがボタンをクリックすることでServer Action経由でログアウト
- Cloud Run環境でのエラーを解消

## テスト
- [x] ローカル環境で動作確認
- [x] 古いセッション形式での動作確認
- [x] Cloud Run環境でのエラー解消確認

## 関連
- 前提となるPR: #23 (Snowflake ID検証ロジックの追加)